### PR TITLE
Release bevy_serialport v0.6, compatible with bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_serialport"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["FoxZoOL <zhooul@gmail.com>"]
 description = "async serial port Plugin for bevy"
@@ -14,7 +14,7 @@ categories = ["game-development", "hardware-support"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.12.0", default-features = false }
+bevy = { version = "0.13", default-features = false }
 bytes = "1.1.0"
 futures = "0.3"
 parking_lot = { version = "0.12" }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ fn send_test_data(mut serial_res: ResMut<SerialResource>) {
 
 | bevy | bevy_serialport |
 |------|-----------------|
+| 0.13 | 0.6             |
 | 0.12 | 0.5             |
 | 0.11 | 0.4             |
 | 0.10 | 0.3             |


### PR DESCRIPTION
Allow this version of bevy_serialport to be used for patch releases of bevy, which would not be the case if we pinned to 0.13.0

We have tested that this lib works without changes in bevy 0.13.0 in our game: https://github.com/thetawavegame/thetawave/pull/160