### PR TITLE
Upgrade to Bevy 0.19.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-05-14
+
+### Changed
+- Upgrade to Bevy 0.19.0-rc.1
+- Updated all Bevy dependencies to 0.19.0-rc.1 compatible versions
+  - bevy_app: 0.19.0-rc.1
+  - bevy_ecs: 0.19.0-rc.1
+  - bevy_log: 0.19.0-rc.1
+  - bevy_derive: 0.19.0-rc.1
+  - bevy_utils: 0.19.0-rc.1
+- Bump crate version to 0.12.0
+
+### Compatibility
+- **Bevy 0.18**: `bevy_serialport` 0.11.0
+- **Bevy 0.19**: `bevy_serialport` 0.12.0
+
+### Verified
+- ✅ All unit tests pass
+- ✅ `cargo check --all-targets` passes
+- ✅ `cargo clippy --all-targets -- -D warnings` passes
+
 ## [0.11.0] - 2026-01-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_serialport"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["FoxZoOL <zhooul@gmail.com>"]
 description = "Async serial port plugin for Bevy game engine with enhanced error handling and convenience APIs"
@@ -21,11 +21,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.18.0" }
-bevy_ecs = { version = "0.18.0" }
-bevy_log = { version = "0.18.0" }
-bevy_derive = { version = "0.18.0" }
-bevy_utils = { version = "0.18.0" }
+bevy_app = { version = "0.19.0-rc.1" }
+bevy_ecs = { version = "0.19.0-rc.1"}
+bevy_log = { version = "0.19.0-rc.1" }
+bevy_derive = { version = "0.19.0-rc.1" }
+bevy_utils = { version = "0.19.0-rc.1" }
 bytes = "1.8"
 futures = "0.3"
 parking_lot = { version = "0.12" }
@@ -36,7 +36,7 @@ tokio-util = { version = "0.7.12", features = ["codec"] }
 tokio-serial = "5.4.5"
 
 [dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.19.0-rc.1", default-features = false, features = ["bevy_log"] }
 clap = { version = "4.5", features = ["derive"] }
 tempdir = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.19.0-rc.1" }
-bevy_ecs = { version = "0.19.0-rc.1"}
-bevy_log = { version = "0.19.0-rc.1" }
-bevy_derive = { version = "0.19.0-rc.1" }
-bevy_utils = { version = "0.19.0-rc.1" }
+bevy_app = { version = "0.19.0-rc.2" }
+bevy_ecs = { version = "0.19.0-rc.2"}
+bevy_log = { version = "0.19.0-rc.2" }
+bevy_derive = { version = "0.19.0-rc.2" }
+bevy_utils = { version = "0.19.0-rc.2" }
 bytes = "1.8"
 futures = "0.3"
 parking_lot = { version = "0.12" }
@@ -36,7 +36,7 @@ tokio-util = { version = "0.7.12", features = ["codec"] }
 tokio-serial = "5.4.5"
 
 [dev-dependencies]
-bevy = { version = "0.19.0-rc.1", default-features = false, features = ["bevy_log"] }
+bevy = { version = "0.19.0-rc.2", default-features = false, features = ["bevy_log"] }
 clap = { version = "4.5", features = ["derive"] }
 tempdir = "0.3"
 


### PR DESCRIPTION
## Summary

Upgrade bevy_serialport from Bevy 0.18.0 to 0.19.0-rc.1.

## Changes

- Bump all bevy dependencies to 0.19.0-rc.1
  - bevy_app, bevy_ecs, bevy_log, bevy_derive, bevy_utils
- Bump dev-dependencies bevy to 0.19.0-rc.1
- Bump crate version to 0.12.0

## Verification

- [x] `cargo check --all-targets` passes
- [x] `cargo test --lib` passes (3 tests)
- [x] `cargo clippy --all-targets -- -D warnings` passes

## Notes

This PR targets Bevy 0.19.0-rc.1. Once Bevy 0.19 stable is released, the dependency versions can be updated from `-rc.1` to the stable release.